### PR TITLE
Style - Update Mobile Mixin

### DIFF
--- a/src/assets/styles/_mixins.scss
+++ b/src/assets/styles/_mixins.scss
@@ -1,5 +1,5 @@
 @mixin Mobile {
-  @media (max-width: 720px) {
+  @media (max-width: 719px) {
     @content;
   }
 }


### PR DESCRIPTION
# Changes
- style: Patch Mobile mixin by 1px to not overlap Tablet
  - Originally between 720px and 721px width, UI rendered with oddities 